### PR TITLE
Do not search for alert2 specifically

### DIFF
--- a/io/kapacitor.go
+++ b/io/kapacitor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // URL paths for kapacitor requests
@@ -99,7 +100,17 @@ func (k Kapacitor) Status(id string) (map[string]int, error) {
 		glog.Info(err)
 	}
 
-	sa := s.Data["node-stats"]["alert2"]
+	var sa interface{}
+	for key, value := range s.Data["node-stats"] {
+		if strings.HasPrefix(key, "alert") {
+			sa = value
+			break
+		}
+	}
+
+	if sa == nil {
+		return nil, errors.New("kapacitor.status: expected alert.* key to be found on stats")
+	}
 
 	f := make(map[string]int)
 	for k, val := range sa.(map[string]interface{}) {

--- a/io/kapacitor.go
+++ b/io/kapacitor.go
@@ -100,11 +100,19 @@ func (k Kapacitor) Status(id string) (map[string]int, error) {
 		glog.Info(err)
 	}
 
+	f := make(map[string]int)
 	var sa interface{}
 	for key, value := range s.Data["node-stats"] {
 		if strings.HasPrefix(key, "alert") {
 			sa = value
-			break
+			for k, val := range sa.(map[string]interface{}) {
+				switch v := val.(type) {
+				case float64:
+					f[k] += int(v)
+				default:
+					return nil, errors.New("kapacitor.status: wrong response from service")
+				}
+			}
 		}
 	}
 
@@ -112,14 +120,5 @@ func (k Kapacitor) Status(id string) (map[string]int, error) {
 		return nil, errors.New("kapacitor.status: expected alert.* key to be found on stats")
 	}
 
-	f := make(map[string]int)
-	for k, val := range sa.(map[string]interface{}) {
-		switch v := val.(type) {
-		case float64:
-			f[k] = int(v)
-		default:
-			return nil, errors.New("kapacitor.status: wrong response from service")
-		}
-	}
 	return f, nil
 }

--- a/io/kapacitor_test.go
+++ b/io/kapacitor_test.go
@@ -121,3 +121,25 @@ func TestStatusNoAlertFound(t *testing.T) {
 		t.Error("Expected error to be about alert, instead it was: ", err)
 	}
 }
+
+func TestStatusMoreThanOneAlert(t *testing.T) {
+	h := "http://test:9093"
+	k := NewK(h)
+	tid := "task_id"
+	b := []byte(`{"stats": { "node-stats":  { "alert4": { "crits_triggered": 1, "warns_triggered": 1, "oks_triggered": 0 }, "alert2": { "crits_triggered": 0, "warns_triggered": 1, "oks_triggered": 0 }}}}`)
+	expected_status := map[string]int{ "crits_triggered": 1, "warns_triggered": 2, "oks_triggered": 0}
+
+	gock.New(h).
+		Get("/kapacitor/v1/tasks/" + tid).
+		Reply(200).
+		JSON(b)
+
+	status, err := k.Status(tid)
+	if err != nil {
+		t.Error("Status: Error when getting status:: ", err)
+	}
+
+	if ! reflect.DeepEqual(status, expected_status) {
+		t.Error("Status should be ", expected_status)
+	}
+}

--- a/io/kapacitor_test.go
+++ b/io/kapacitor_test.go
@@ -5,6 +5,7 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	"reflect"
 	"testing"
+	"strings"
 )
 
 func TestConstructor(t *testing.T) {
@@ -53,5 +54,70 @@ func TestDelete(t *testing.T) {
 	err := k.Delete(tid)
 	if err != nil {
 		t.Error("Delete: Error when deleting a valid id:: ", err)
+	}
+}
+
+func TestStatusOnAlert2(t *testing.T) {
+	h := "http://test:9093"
+	k := NewK(h)
+	tid := "task_id"
+	b := []byte(`{"stats": { "node-stats": { "alert2": { "crits_triggered": 0, "warns_triggered": 1, "oks_triggered": 0 } } }}`)
+	expected_status := map[string]int{ "crits_triggered": 0, "warns_triggered": 1, "oks_triggered": 0}
+
+	gock.New(h).
+		Get("/kapacitor/v1/tasks/" + tid).
+		Reply(200).
+		JSON(b)
+
+	status, err := k.Status(tid)
+	if err != nil {
+		t.Error("Status: Error when getting status:: ", err)
+	}
+
+	if ! reflect.DeepEqual(status, expected_status) {
+		t.Error("Status should be ", expected_status)
+	}
+}
+
+func TestStatusOnOtherAlert(t *testing.T) {
+	h := "http://test:9093"
+	k := NewK(h)
+	tid := "task_id"
+	b := []byte(`{"stats": { "node-stats": { "alert4": { "crits_triggered": 1, "warns_triggered": 1, "oks_triggered": 0 } } }}`)
+	expected_status := map[string]int{ "crits_triggered": 1, "warns_triggered": 1, "oks_triggered": 0}
+
+	gock.New(h).
+		Get("/kapacitor/v1/tasks/" + tid).
+		Reply(200).
+		JSON(b)
+
+	status, err := k.Status(tid)
+	if err != nil {
+		t.Error("Status: Error when getting status:: ", err)
+	}
+
+	if ! reflect.DeepEqual(status, expected_status) {
+		t.Error("Status should be ", expected_status)
+	}
+}
+
+func TestStatusNoAlertFound(t *testing.T) {
+	h := "http://test:9093"
+	k := NewK(h)
+	tid := "task_id"
+	b := []byte(`{"stats": { "node-stats": {} }}`)
+
+	gock.New(h).
+		Get("/kapacitor/v1/tasks/" + tid).
+		Reply(200).
+		JSON(b)
+
+	_, err := k.Status(tid)
+	if err == nil {
+		t.Error("Expected to return with error")
+	}
+
+	if !strings.HasPrefix(err.Error(), "kapacitor.status: expected alert") {
+		t.Error("Expected error to be about alert, instead it was: ", err)
 	}
 }


### PR DESCRIPTION
The alert key in the status json may vary in different examples, so we
look instead for the first positive match for "alert.*"