### PR TITLE
feat(batch): Replaces .every(*) for 1s so that batch script tests run faster [#6]

### DIFF
--- a/sample/alert_weather_batch.tick
+++ b/sample/alert_weather_batch.tick
@@ -5,7 +5,7 @@ var weather = batch
 		FROM "weather"."default"."temperature"
 		''')
 			.period(5m)
-			.every(1s)
+			.every(10m)
 
 var rain = batch
 	| query('''
@@ -13,7 +13,7 @@ var rain = batch
 		FROM "weather"."default"."temperature"
 	''')
 		.period(5m)
-		.every(5m)
+		.every(3d)
 
 
 // simple case with only one batch query


### PR DESCRIPTION
kapacitor-unit should not wait for the batch queries to be triggered, since it could potentially make the test run too slow. The solution proposed is to change the batch script on the fly before loading it into kapacitor and replace all `.every(**)` for `.every(1s)` so that all the batch queries run every 1s