### PR TITLE
Reuse existing task, replay existing recording and stream speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-cmd:
 	go build cmd/kapacitor-unit/main.go 
 
 run:
-	./cmd/kapacitor-unit/kapacitor-unit
+	./main
 
 start-kapacitor:
 	docker-compose -f infra/docker-compose.yml up -d

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order for all features to be supported, the Kapacitor version running the tes
 
 ```
  $ make install
- $ make build
+ $ make build-cmd
 
  $ make run  	# same as ./cmd/kapacitor-unit/kapacitor-unit
 ```

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -28,10 +28,6 @@ func (c *Config) Validate() {
 	if c.TestsPath == "" {
 		log.Fatal("ERROR: Path for tests definitions (--tests) must be defined")
 	}
-
-	if c.ScriptsDir == "" {
-		log.Fatal("ERROR: Path for where TICKscripts directory (--dir) must be defined")
-	}
 }
 
 // Loads env variables first than overrides with flags if provided

--- a/cmd/kapacitor-unit/main.go
+++ b/cmd/kapacitor-unit/main.go
@@ -35,6 +35,8 @@ func main() {
 
 	// Validates, runs tests in series and print results
 	for _, t := range tests {
+		log.Println("Running Test Name: ", t.Name)
+
 		if err := t.Validate(); err != nil {
 			log.Println(err)
 			continue

--- a/io/io.go
+++ b/io/io.go
@@ -9,4 +9,6 @@ const (
 	kapacitor_write = "/kapacitor/v1/write?"
 	influxdb_write = "/write?"
 	tasks = "/kapacitor/v1/tasks"
+	replays = "/kapacitor/v1/replays"
+	topics = "/kapacitor/v1/alerts/topics"
 )

--- a/io/kapacitor.go
+++ b/io/kapacitor.go
@@ -9,10 +9,16 @@ import (
 	"net/http"
 	"strings"
 	"regexp"
+	"strconv"
+	"time"
 )
 
 type Status struct {
 	Data map[string]map[string]interface{} `json:"stats"`
+}
+
+type Topics struct {
+	Data []map[string]interface{} `json:"topics"`
 }
 
 // Kapacitor service configurations
@@ -46,12 +52,57 @@ func (k Kapacitor) Load(f map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	
 	u := k.Host + tasks
 	res, err := k.Client.Post(u, "application/json", bytes.NewBuffer(j))
 	if err != nil {
 		return err
 	}
+
+	if res.StatusCode != 200 {
+		r, _ := ioutil.ReadAll(res.Body)
+		return errors.New(res.Status + ":: " + string(r))
+	}
+	return nil
+}
+
+// Modify Task
+func (k Kapacitor) ModifyTasks(f map[string]interface{}) error {
+	glog.Info("DEBUG:: Kapacitor modify existing task: ", f["id"])
+
+	j, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+
+	u := k.Host + tasks + "/" + f["id"].(string)
+	r, err := http.NewRequest("PATCH", u, bytes.NewBuffer(j))
+	if err != nil {
+		return err
+	}
+	_, err = k.Client.Do(r)
+	if err != nil {
+		return err
+	}
+	glog.Info("DEBUG:: Kapacitor modified task: ", f["id"])
+
+	return nil
+}
+
+// Replay
+func (k Kapacitor) Replay(f map[string]interface{}) error {
+	glog.Info("DEBUG:: Kapacitor replay recording: ", f["recording"], " on Task: ", f["task"])
+
+	j, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+
+	u := k.Host + replays
+	res, err := k.Client.Post(u, "application/json", bytes.NewBuffer(j))
+	if err != nil {
+		return err
+	}
+
 
 	if res.StatusCode != 200 {
 		r, _ := ioutil.ReadAll(res.Body)
@@ -76,9 +127,20 @@ func (k Kapacitor) Delete(id string) error {
 }
 
 // Adds test data to kapacitor
-func (k Kapacitor) Data(data []string, db string, rp string) error {
+func (k Kapacitor) Data(data []string, db string, rp string, clock string) error {
 	u := k.Host + kapacitor_write + "db=" + db + "&rp=" + rp
+	delay := 0
+	prevTime := 9223372036854775806 //max valid timestamp
 	for _, d := range data {
+		if clock == "real" {
+			line := strings.Split(d, " ")
+			curTime, _ := strconv.Atoi(line[2])
+			delay = curTime - prevTime
+
+			glog.Info("DEBUG:: sleep: ", time.Duration(delay))
+			time.Sleep(time.Duration(delay) * time.Nanosecond)
+			prevTime = curTime
+		}
 		_, err := k.Client.Post(u, "application/x-www-form-urlencoded",
 			bytes.NewBuffer([]byte(d)))
 		if err != nil {
@@ -122,6 +184,36 @@ func (k Kapacitor) Status(id string) (map[string]int, error) {
 		return nil, errors.New("kapacitor.status: expected alert.* key to be found on stats")
 	}
 	return f, nil
+}
+
+// clear topics
+func (k Kapacitor) ClearTopics() error {
+	glog.Info("DEBUG:: Kapacitor delete all topics ")
+	u := k.Host + topics
+	res, err := k.Client.Get(u)
+	if err != nil {
+		return err
+	}
+	var s Topics
+	b, err := ioutil.ReadAll(res.Body)
+	err = json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	for _, value := range s.Data {
+		glog.Info("DEBUG:: Kapacitor delete topic: ", value["id"].(string))
+		u := k.Host + topics + "/" + value["id"].(string)
+		r, err := http.NewRequest("DELETE", u, nil)
+		if err != nil {
+			return err
+		}
+		_, err = k.Client.Do(r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Replaces '.every(*)' for the batch request to be performed every 1s to speed up the test

--- a/task/task.go
+++ b/task/task.go
@@ -19,14 +19,16 @@ func New(n string, p string) (*Task, error) {
 		Name: n,
 		Path: p}
 
-	if !strings.HasSuffix(p, "/") {
-		p = p + "/"
-	}
+	if p != "" {
+		if !strings.HasSuffix(p, "/") {
+			p = p + "/"
+		}
 
-	s, err := ioutil.ReadFile(p + n)
-	if err != nil {
-		return nil, err
+		s, err := ioutil.ReadFile(p + n)
+		if err != nil {
+			return nil, err
+		}
+		task.Script = string(s[:])
 	}
-	task.Script = string(s[:])
 	return &task, nil
 }


### PR DESCRIPTION
* allow the use existing task in kapacitor w/c
  were loaded by kapacitor via [load]
* clear stats and topics before running each test.
* support for replaying existing recordings
  using "recording_id" in test yaml
* configurable stream speed real/fast, for
  testing deadman