### PR TITLE
Feature Additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-kapacitor-unit
 notes.md
 *.swp
 *.swo

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ type Config struct {
 	ScriptsDir    string
 	InfluxdbHost  string
 	KapacitorHost string
+	NoBanner bool
 }
 
 func envOrDefault(env string, def string) string {
@@ -39,6 +40,7 @@ func Load() *Config {
 		ScriptsDir: envOrDefault("KU_SCRIPTS_DIR", ""),
 		InfluxdbHost: envOrDefault("KU_INFLUX_HOST", "http://localhost:8086"),
 		KapacitorHost: envOrDefault("KU_KAPACITOR_HOST", "http://localhost:9092"),
+		NoBanner: false,
 	}
 
 	influxdbHost := flag.String("influxdb", "",
@@ -47,8 +49,14 @@ func Load() *Config {
 		"Kapacitor host")
 	testsPath := flag.String("tests", "", "Tests definition file")
 	scriptsDir := flag.String("dir", "", "TICKscripts directory")
+	noBanner := flag.Bool("q", false, "Dont print banner on startup")
+	
+
 
 	flag.Parse()
+	if *noBanner == true {
+		conf.NoBanner = true
+	}
 
 	if *influxdbHost != "" {
 		conf.InfluxdbHost = *influxdbHost

--- a/cmd/kapacitor-unit/main.go
+++ b/cmd/kapacitor-unit/main.go
@@ -126,8 +126,27 @@ func testConfig(fileName string) (TestCollection, error) {
 		tests = append(tests, fileTests...)
 	}
 
+	for i, t := range tests {
+		fmt.Println(t.DataPath)
+		if t.DataPath != "" {
+			fmt.Println("Loading data from file")
+			var data []string
+			b, err := ioutil.ReadFile(t.DataPath)
+			if err != nil {
+				return nil, err
+			}
+			err = yaml.Unmarshal(b, &data)
+			if err !=  nil{
+				fmt.Println("Unmarshal error")
+				 return nil, err
+			}
+			tests[i].Data = data
+		}
+	}
+
 	return tests, nil
 }
+
 
 //Populates each of Test in Configuration struct with an initialized Task
 func initTests(c TestCollection, p string) error {

--- a/cmd/kapacitor-unit/main.go
+++ b/cmd/kapacitor-unit/main.go
@@ -18,9 +18,12 @@ import (
 type TestCollection []test.Test
 
 func main() {
-	fmt.Println(renderWelcome())
+	
 
 	f := cli.Load()
+	if !f.NoBanner {
+		fmt.Println(renderWelcome())
+	}
 	kapacitor := io.NewKapacitor(f.KapacitorHost)
 	influxdb := io.NewInfluxdb(f.InfluxdbHost)
 
@@ -134,6 +137,7 @@ func initTests(c TestCollection, p string) error {
 			return err
 		}
 		c[i].Task = *tk
+
 	}
 	return nil
 }


### PR DESCRIPTION
* added option to suppress banner
* added `reset_topics` option for tasks to allow topics for tasks to be force reset.
* added `precision` option to allow for the changing of the precision of the data points
* added the ability to specify a path to a yaml data file rather than the data itself (this helps when you have a lot of test data)
* removed the retention policy on the database created for influxdb batches, as this rp breaks testing for batches with data that covers more than one hour.
* added `offset_unit` option
* added a new possible value to `clock` option: "offset":
    when used with stream this means that all the data points will be written (time * `offset_unit`) after the start of the test so `foo field=1 1000` with `offset_unit: ms` would write the point 1s after the start of the test
    This should have no effect when used with a batch task
* added `shift` to allow timeshifting batch points that are relative and use 'offset'